### PR TITLE
Revert nvm change in `run_tests`

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -29,13 +29,6 @@ run_tests () {
     exit 0
   fi
 
-  if [ "$TRAVIS_BRANCH" = "next" ]; then
-    echo
-    echo "Using Node LTS for pull request targeting `next`."
-    echo
-    nvm use lts
-  fi
-
   echo
   echo $(head -c 79 /dev/zero | tr '\0' '=')
   echo "meta git update"


### PR DESCRIPTION
This attempt didn't work - `nvm` is not available in within the shell script. . . . temporarily disabling. 