### PR TITLE
Fix/lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm
-ENV LTS_VERSION 8.11.1
+ENV NODE_VERSION 8.11.1
 
 # install nvm
 # https://github.com/creationix/nvm#install-script
@@ -20,8 +20,8 @@ RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/i
 
 # install node and npm
 RUN source $NVM_DIR/nvm.sh \
-    && nvm install $LTS_VERSION \
-    && nvm alias default $LTS_VERSION \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
     && nvm use default
    
 # add node and npm to path so the commands are available

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
 
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION 6.9.1
 ENV LTS_VERSION 8.11.1
 
 # install nvm
@@ -21,12 +20,10 @@ RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/i
 
 # install node and npm
 RUN source $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
     && nvm install $LTS_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm alias lts $LTS_VERSION \
-    && nvm use lts
-
+    && nvm alias default $LTS_VERSION \
+    && nvm use default
+   
 # add node and npm to path so the commands are available
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,6 @@ RUN source $NVM_DIR/nvm.sh \
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-# fix bug with npm permissions as root (https://github.com/npm/npm/issues/13306)
-RUN cd $(npm root -g)/npm && \
-    npm install fs-extra && \
-    sed -i -e s/graceful-fs/fs-extra/ -e s/fs.rename/fs.move/ ./lib/utils/rename.js
-
 # use https checkout to avoid requiring deploy keys
 RUN git config --global url."https://github.com/".insteadOf "git@github.com:"
 


### PR DESCRIPTION
+ Remove 6.9.1 installation and aliases. Use 8.11.1 as the default. 
+ Remove npm permissions hack that fails on 8.11.1 and [no longer issue](https://github.com/npm/npm/issues/13306#issuecomment-291296416) in NPM 5.
+ [Build link](https://hub.docker.com/r/truffle/ci/builds/) 

The docker build for the last change here failed. Not sure about cause - seems like it might be a problem aliasing to the word`lts`? Build logs look like this at the end:
```
Step 9/23 : RUN source $NVM_DIR/nvm.sh     && nvm install $NODE_VERSION     && nvm install $LTS_VERSION     && nvm alias default $NODE_VERSION     && nvm alias lts $LTS_VERSION     && nvm use lts

 ---> Running in 6eda672a33da

Downloading and installing node v6.9.1...

[91mDownloading https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz...
[0m
[91m
######                                                                     9.5%[0m
[91m
#########################                                                 35.7%[0m
[91m
###################################################                       71.1%[0m
[91m
######################################################################## 100.0%
[0m
[91mComputing checksum with sha256sum
[0m
[91mChecksums matched!
[0m
Now using node v6.9.1 (npm v3.10.8)

Creating default alias: default -> 6.9.1 (-> v6.9.1 *)

Downloading and installing node v8.11.1...

[91mDownloading https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-x64.tar.xz...
[0m
[91m
#                                                                          1.9%[0m
[91m
##########                                                                15.0%[0m
[91m
###########################                                               38.2%[0m
[91m
#################################################                         68.1%[0m
[91m
######################################################################## 100.0%
[0m
[91mComputing checksum with sha256sum
[0m
[91mChecksums matched!
[0m
Now using node v8.11.1 (npm v5.6.0)

default -> 6.9.1 (-> v6.9.1 *)

[91mtee: /usr/local/nvm/alias/lts: Is a directory
[0m
lts -> 8.11.1 (-> v8.11.1 *)

[91mN/A: version "lts -> N/A" is not yet installed.

You need to run "nvm install lts" to install it before using it.
[0m
Removing intermediate container 6eda672a33da

The command '/bin/sh -c source $NVM_DIR/nvm.sh     && nvm install $NODE_VERSION     && nvm install $LTS_VERSION     && nvm alias default $NODE_VERSION     && nvm alias lts $LTS_VERSION     && nvm use lts' returned a non-zero code: 3
``` 